### PR TITLE
Migrate content to the system's enrichers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0
+
+- feature: v12 compatibility
+- feature: Migration to the system's enrichers
+
 # 0.3
 
 - feature: add Roll Item command to use items just like a system-generated macro

--- a/css/inline-roll-cmd.css
+++ b/css/inline-roll-cmd.css
@@ -41,3 +41,18 @@ a.inline-roll-cmd:hover .item-image {
 a.inline-roll-cmd .item-image:hover {
   background-image: url("../../../icons/svg/d20-black.svg") !important;
 }
+
+/* migration form styling */
+.ircmigration .warning {
+  background: rgba(214, 150, 0, 0.8);
+  border: 1px solid var(--color-level-warning);
+  border-radius: 5px;
+  box-shadow: 0 0 10px var(--color-shadow-dark);
+  color: var(--color-text-light-1);
+  font-size: var(--font-size-14);
+  text-shadow: 1px 1px black;
+  margin-bottom: 1em;
+  margin-top: 1em;
+  padding: 6px 8px;
+  line-height: 20px;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,16 @@
+{
+  "IRC": {
+    "migrateMenuName": "Migrate to System's Enrichers",
+    "migrateMenuLabel": "Migrate",
+    "migrateWorldStart": "Migrating world data to the system's enrichers",
+    "migrateWorldEnd": "Migrating world data to the system's enrichers complete",
+    "migrateCompendiumStart": "Migrating pack {pack} to the system's enrichers",
+    "migrateCompendiumEnd": "Migrating pack {pack} to the system's enrichers complete",
+    "migrateTitle": "Migrate Inline Roll Commands",
+    "migrateParagraph1": "Migrate the world data (actors, items, and unlinked tokens on scenes) or compendium packs. This will convert any Inline Roll Commands to the new enrichers the D&amp;D 5e system includes.",
+    "migrateParagraph2": "Example: <code>[[/rollSkill ath]]</code> is converted to <code>[[/skill ath]]</code>",
+    "migratePackLabel": "Pack to Migrate",
+    "migrateWorld": "Migrate World",
+    "migratePack": "Migrate Pack"
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,7 @@
     "migrateTitle": "Migrate Inline Roll Commands",
     "migrateParagraph1": "Migrate the world data (actors, items, and unlinked tokens on scenes) or compendium packs. This will convert any Inline Roll Commands to the new enrichers the D&amp;D 5e system includes.",
     "migrateParagraph2": "Example: <code>[[/rollSkill ath]]</code> is converted to <code>[[/skill ath]]</code>",
+    "migrateBackupWarning": "Backup your data before migrating, just in case.",
     "migratePackLabel": "Pack to Migrate",
     "migrateWorld": "Migrate World",
     "migratePack": "Migrate Pack"

--- a/module.json
+++ b/module.json
@@ -27,6 +27,9 @@
   "styles": [
     "css/inline-roll-cmd.css"
   ],
+  "languages": [
+    { "lang": "en", "name": "English", "path": "lang/en.json" }
+  ],
   "url": "replaced by workflow",
   "manifest": "replaced by workflow",
   "download": "replaced by workflow",

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "version": "0.1",
   "compatibility": {
     "minimum": 11.315,
-    "verified": 11
+    "verified": 12
   },
   "relationships": {
     "systems": [
@@ -20,7 +20,7 @@
         "type": "system",
         "compatibility": {
           "minimum": "3.0.0",
-          "verified": "3.0.4"
+          "verified": "3.2.0"
         }
       }
     ]

--- a/module.json
+++ b/module.json
@@ -10,14 +10,18 @@
   ],
   "version": "0.1",
   "compatibility": {
-    "minimum": 10,
-    "verified": 10
+    "minimum": 11.315,
+    "verified": 11
   },
   "relationships": {
     "systems": [
       {
         "id": "dnd5e",
-        "type": "system"
+        "type": "system",
+        "compatibility": {
+          "minimum": "3.0.0",
+          "verified": "3.0.4"
+        }
       }
     ]
   },

--- a/src/inline-roll-cmd.js
+++ b/src/inline-roll-cmd.js
@@ -5,40 +5,53 @@ import { debug, MODULE_NAME } from "./util.js";
  */
 Hooks.once("devModeReady", ({ registerPackageDebugFlag }) => registerPackageDebugFlag(MODULE_NAME));
 
+const skillPattern =
+  /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Skill (\w+)\]\](?:{([^}]+)})?/gi;
+const abilityPattern =
+  /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Ability (\w+)\]\](?:{([^}]+)})?/gi;
+const savePattern =
+  /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Save (\w+)\]\](?:{([^}]+)})?/gi;
+const itemPattern = /\[\[\/rollItem ([^\]]+)\]\](?:{([^}]+)})?/gi;
 /**
  * Register the text enrichers to create the deferred inline roll buttons.
  */
 Hooks.once("init", () => {
   // example: [[/rollSkill ath]]
   CONFIG.TextEditor.enrichers.push({
-    pattern:
-      /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Skill (\w+)\]\](?:{([^}]+)})?/gi,
+    pattern: skillPattern,
     enricher: createSkill,
   });
 
   // example: [[/rollAbility str]]
   CONFIG.TextEditor.enrichers.push({
-    pattern:
-      /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Ability (\w+)\]\](?:{([^}]+)})?/gi,
+    pattern: abilityPattern,
     enricher: createAbility,
   });
 
   // example: [[/rollSave dex]]
   CONFIG.TextEditor.enrichers.push({
-    pattern:
-      /\[\[\/(r|roll|pr|publicroll|gmr|gmroll|br|broll|blindroll|sr|selfroll)Save (\w+)\]\](?:{([^}]+)})?/gi,
+    pattern: savePattern,
     enricher: createSave,
   });
 
   // example: [[/rollItem Dagger]]
   CONFIG.TextEditor.enrichers.push({
-    pattern: /\[\[\/rollItem ([^\]]+)\]\](?:{([^}]+)})?/gi,
+    pattern: itemPattern,
     enricher: createItem,
   });
 
   // activate listeners
   const body = $("body");
   body.on("click", "a.inline-roll-cmd", onClick);
+
+  // register setting
+  game.settings.registerMenu("inline-roll-cmd", "migrateMenu", {
+    name: "Migrate to System's Enrichers",
+    label: "Migrate",
+    icon: "fas fa-refresh",
+    type: InlineMigrationApplication,
+    restricted: true,
+  });
 });
 
 /**
@@ -105,9 +118,7 @@ function createItem(match, options) {
     if (item) img = item.img;
   }
 
-  return img
-    ? createItemButton(itemName, flavor, img)
-    : createButton("roll", "item", { itemName }, flavor, itemName);
+  return img ? createItemButton(itemName, flavor, img) : createButton("roll", "item", { itemName }, flavor, itemName);
 }
 
 /**
@@ -214,5 +225,227 @@ async function onClick(event) {
     case "item":
       dnd5e.documents.macro.rollItem(a.dataset.itemName);
       break;
+  }
+}
+
+class InlineMigration {
+  async migrateWorld() {
+    ui.notifications.info("Migrating world data to the system's enrichers", { permanent: true });
+
+    // Migrate actors
+    const actorUpdates = await this._migrateActors(game.actors);
+    Actor.updateDocuments(actorUpdates);
+
+    // Migrate items
+    const itemUpdates = this._migrateItems(game.items);
+    Item.updateDocuments(itemUpdates);
+
+    // Migrate unlinked actors on scenes
+    await this._migrateScenes(game.scenes);
+
+    ui.notifications.info("Migrating world data to the system's enrichers complete", { permanent: true });
+  }
+
+  async _migrateScenes(scenes) {
+    for (const scene of scenes) {
+      for (const token of scene.tokens) {
+        if (token.actorLink || !token.actor) continue;
+
+        const updateData = await this.migrateActorData(token.actor);
+        // if it has item updates, do them now
+        if (!foundry.utils.isEmpty(updateData.items)) {
+          await token.actor.updateEmbeddedDocuments("Item", updateData.items);
+          delete updateData.items;
+        }
+        // if there are updates to the actor, do them now
+        if (!foundry.utils.isEmpty(updateData)) await token.actor.update(updateData);
+      }
+    }
+  }
+
+  _migrateItems(items) {
+    const itemUpdates = [];
+    for (const item of items) {
+      const updateData = this.migrateItemData(item);
+      // if there are updates, batch them
+      if (!foundry.utils.isEmpty(updateData)) {
+        updateData._id = item.id;
+        itemUpdates.push(updateData);
+      }
+    }
+    return itemUpdates;
+  }
+
+  async _migrateActors(actors) {
+    const actorUpdates = [];
+    for (const actor of actors) {
+      const updateData = await this.migrateActorData(actor);
+      // if it has item updates, do them now
+      if (!foundry.utils.isEmpty(updateData.items)) {
+        debug("About to update an actor's items", actor.name, updateData.items);
+        await actor.updateEmbeddedDocuments("Item", updateData.items);
+        delete updateData.items;
+      }
+      // if there are updates to the actor, batch them
+      if (!foundry.utils.isEmpty(updateData)) {
+        updateData._id = actor.id;
+        actorUpdates.push(updateData);
+      }
+    }
+    return actorUpdates;
+  }
+
+  async migrateCompendium(pack) {
+    if (pack.locked || !["Actor", "Item", "Scene"].includes(pack.documentName)) return;
+    ui.notifications.info(`Migrating pack ${pack.title} to the system's enrichers`, { permanent: true });
+
+    for (const ids of this.idChunks(pack)) {
+      const updates = [];
+
+      switch (pack.documentName) {
+        case "Actor":
+          const actors = await pack.getDocuments({ _id__in: ids });
+          const actorUpdates = await this._migrateActors(actors);
+          Actor.updateDocuments(actorUpdates, { pack: pack.collection });
+          break;
+        case "Item":
+          const items = await pack.getDocuments({ _id__in: ids });
+          const itemUpdates = this._migrateItems(items);
+          Item.updateDocuments(itemUpdates, { pack: pack.collection });
+          break;
+        case "Scene":
+          const scenes = await pack.getDocuments({ _id__in: ids });
+          await this._migrateScenes(scenes);
+          break;
+      }
+    }
+
+    ui.notifications.info(`Migrating pack ${pack.title} to the system's enrichers complete`, { permanent: true });
+  }
+
+  async migrateActorData(actor) {
+    const updateData = {};
+
+    // Convert the different description and biography fields
+    if (actor.type === "group") {
+      const full = this.toSystemEnrichers(actor.system.description.full || "");
+      if (full) updateData["system.description.full"] = full;
+      const summary = this.toSystemEnrichers(actor.system.description.summary || "");
+      if (summary) updateData["system.description.summary"] = summary;
+    } else {
+      const value = this.toSystemEnrichers(actor.system.details.biography.value || "");
+      if (value) updateData["system.details.biography.value"] = value;
+      const pub = this.toSystemEnrichers(actor.system.details.biography.public || "");
+      if (pub) updateData["system.details.biography.public"] = pub;
+    }
+
+    // Convert items
+    const itemUpdates = actor.items.reduce((updates, item) => {
+      const itemUpdate = this.migrateItemData(item);
+      if (!foundry.utils.isEmpty(itemUpdate)) {
+        itemUpdate._id = item.id;
+        updates.push(itemUpdate);
+      }
+      return updates;
+    }, []);
+    if (!foundry.utils.isEmpty(updateData)) debug("migrateActorData item updates:", itemUpdates);
+    updateData.items = itemUpdates;
+
+    return updateData;
+  }
+
+  *idChunks(pack) {
+    const ids = pack.index.map((i) => i._id);
+    while (ids.length) {
+      yield ids.splice(0, 100);
+    }
+  }
+
+  migrateItemData(item) {
+    const updateData = {};
+
+    // Convert the description fields
+    const desc = this.toSystemEnrichers(item.system.description.value || "");
+    if (desc) updateData["system.description.value"] = desc;
+    const chat = this.toSystemEnrichers(item.system.description.chat || "");
+    if (chat) updateData["system.description.chat"] = chat;
+
+    // Not each item type has this (e.g. feature)
+    if (item.system.unidentified?.description) {
+      const unident = this.toSystemEnrichers(item.system.unidentified.description);
+      if (unident) updateData["system.unidentified.description"] = unident;
+    }
+
+    if (!foundry.utils.isEmpty(updateData)) debug("migrateItemData updates:", updateData);
+    return updateData;
+  }
+
+  toSystemEnrichers(text) {
+    let replaced = false;
+    const replacers = [
+      {
+        pattern: skillPattern,
+        replacement: (match, _, skillId, flavor) => {
+          replaced = true;
+          return flavor ? `[[/skill ${skillId}]]{${flavor}}` : `[[/skill ${skillId}]]`;
+        },
+      },
+      {
+        pattern: abilityPattern,
+        replacement: (match, _, abilityId, flavor) => {
+          replaced = true;
+          return flavor ? `[[/check ${abilityId}]]{${flavor}}` : `[[/check ${abilityId}]]`;
+        },
+      },
+      {
+        pattern: savePattern,
+        replacement: (match, _, abilityId, flavor) => {
+          replaced = true;
+          return flavor ? `[[/save ${abilityId}]]{${flavor}}` : `[[/save ${abilityId}]]`;
+        },
+      },
+      {
+        pattern: itemPattern,
+        replacement: (match, itemName, flavor) => {
+          replaced = true;
+          return flavor ? `[[/item ${itemName}]]{${flavor}}` : `[[/item ${itemName}]]`;
+        },
+      },
+    ];
+
+    const newText = replacers.reduce((t, { pattern, replacement }) => t.replaceAll(pattern, replacement), text);
+    return replaced ? newText : undefined;
+  }
+}
+// expose this globally
+globalThis.inlineMigration = new InlineMigration();
+
+class InlineMigrationApplication extends FormApplication {
+  static get defaultOptions() {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      title: "Migrate Inline Roll Commands",
+      template: "modules/inline-roll-cmd/templates/migration.hbs",
+      width: 500,
+    });
+  }
+
+  async getData(options) {
+    return {
+      packs: game.packs.contents.filter((pack) => {
+        return !pack.locked && ["Actor", "Item", "Scene"].includes(pack.documentName);
+      }),
+    };
+  }
+
+  async _updateObject(event, formData) {
+    const button = event.submitter;
+    const action = button.dataset.action;
+    if (action === "migrate-world") {
+      return inlineMigration.migrateWorld();
+    } else if (action === "migrate-pack") {
+      const packId = formData.pack;
+      const pack = game.packs.get(packId);
+      return inlineMigration.migrateCompendium(pack);
+    }
   }
 }

--- a/src/inline-roll-cmd.js
+++ b/src/inline-roll-cmd.js
@@ -423,6 +423,7 @@ globalThis.inlineMigration = new InlineMigration();
 class InlineMigrationApplication extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
+      classes: ["ircmigration"],
       title: "IRC.migrateTitle",
       template: "modules/inline-roll-cmd/templates/migration.hbs",
       width: 500,

--- a/src/inline-roll-cmd.js
+++ b/src/inline-roll-cmd.js
@@ -46,8 +46,8 @@ Hooks.once("init", () => {
 
   // register setting
   game.settings.registerMenu("inline-roll-cmd", "migrateMenu", {
-    name: "Migrate to System's Enrichers",
-    label: "Migrate",
+    name: "IRC.migrateMenuName",
+    label: "IRC.migrateMenuLabel",
     icon: "fas fa-refresh",
     type: InlineMigrationApplication,
     restricted: true,
@@ -230,7 +230,7 @@ async function onClick(event) {
 
 class InlineMigration {
   async migrateWorld() {
-    ui.notifications.info("Migrating world data to the system's enrichers", { permanent: true });
+    ui.notifications.info(game.i18n.localize("IRC.migrateWorldStart"), { permanent: true });
 
     // Migrate actors
     const actorUpdates = await this._migrateActors(game.actors);
@@ -243,7 +243,7 @@ class InlineMigration {
     // Migrate unlinked actors on scenes
     await this._migrateScenes(game.scenes);
 
-    ui.notifications.info("Migrating world data to the system's enrichers complete", { permanent: true });
+    ui.notifications.info(game.i18n.localize("IRC.migrateWorldEnd"), { permanent: true });
   }
 
   async _migrateScenes(scenes) {
@@ -297,7 +297,7 @@ class InlineMigration {
 
   async migrateCompendium(pack) {
     if (pack.locked || !["Actor", "Item", "Scene"].includes(pack.documentName)) return;
-    ui.notifications.info(`Migrating pack ${pack.title} to the system's enrichers`, { permanent: true });
+    ui.notifications.info(game.i18n.format("IRC.migrateCompendiumStart", { pack: pack.title }), { permanent: true });
 
     for (const ids of this.idChunks(pack)) {
       const updates = [];
@@ -320,7 +320,7 @@ class InlineMigration {
       }
     }
 
-    ui.notifications.info(`Migrating pack ${pack.title} to the system's enrichers complete`, { permanent: true });
+    ui.notifications.info(game.i18n.format("IRC.migrateCompendiumEnd", { pack: pack.title }), { permanent: true });
   }
 
   async migrateActorData(actor) {
@@ -423,7 +423,7 @@ globalThis.inlineMigration = new InlineMigration();
 class InlineMigrationApplication extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      title: "Migrate Inline Roll Commands",
+      title: "IRC.migrateTitle",
       template: "modules/inline-roll-cmd/templates/migration.hbs",
       width: 500,
     });

--- a/src/inline-roll-cmd.js
+++ b/src/inline-roll-cmd.js
@@ -431,9 +431,9 @@ class InlineMigrationApplication extends FormApplication {
 
   async getData(options) {
     return {
-      packs: game.packs.contents.filter((pack) => {
-        return !pack.locked && ["Actor", "Item", "Scene"].includes(pack.documentName);
-      }),
+      packs: game.packs.contents.filter(
+        (pack) => !pack.locked && ["Actor", "Item", "Scene"].includes(pack.documentName)
+      ),
     };
   }
 

--- a/templates/migration.hbs
+++ b/templates/migration.hbs
@@ -2,6 +2,8 @@
   <p>{{{localize "IRC.migrateParagraph1"}}}</p>
   <p>{{{localize "IRC.migrateParagraph2"}}}</p>
 
+  <div class="warning"><i class="fas fa-triangle-exclamation"></i> {{localize "IRC.migrateBackupWarning"}}</div>
+
   <div class="form-group">
     <label>{{localize "IRC.migratePackLabel"}}</label>
     <select name="pack">

--- a/templates/migration.hbs
+++ b/templates/migration.hbs
@@ -1,9 +1,9 @@
 <form autocomplete="off" onsubmit="event.preventDefault();">
-  <p>Migrate the world data (actors, items, and unlinked tokens on scenes) or compendium packs. This will convert any Inline Roll Commands to the new enrichers the D&amp;D 5e system includes.</p>
-  <p>Example: <code>[[/rollSkill ath]]</code> is converted to <code>[[/skill ath]]</code></p>
+  <p>{{{localize "IRC.migrateParagraph1"}}}</p>
+  <p>{{{localize "IRC.migrateParagraph2"}}}</p>
 
   <div class="form-group">
-    <label>Pack to Migrate</label>
+    <label>{{localize "IRC.migratePackLabel"}}</label>
     <select name="pack">
       {{#each packs}}
         <option value="{{this.metadata.id}}">{{this.title}} [{{this.metadata.packageName}}]</option>
@@ -12,7 +12,7 @@
   </div>
   
   <div class="form-group">
-    <button type="submit" data-action="migrate-world"><i class="fas fa-globe"></i> Migrate World</button>
-    <button type="submit" data-action="migrate-pack"><i class="fas fa-atlas"></i> Migrate Pack</button>
+    <button type="submit" data-action="migrate-world"><i class="fas fa-globe"></i> {{localize "IRC.migrateWorld"}}</button>
+    <button type="submit" data-action="migrate-pack"><i class="fas fa-atlas"></i> {{localize "IRC.migratePack"}}</button>
   </div>
 </form>

--- a/templates/migration.hbs
+++ b/templates/migration.hbs
@@ -1,0 +1,18 @@
+<form autocomplete="off" onsubmit="event.preventDefault();">
+  <p>Migrate the world data (actors, items, and unlinked tokens on scenes) or compendium packs. This will convert any Inline Roll Commands to the new enrichers the D&amp;D 5e system includes.</p>
+  <p>Example: <code>[[/rollSkill ath]]</code> is converted to <code>[[/skill ath]]</code></p>
+
+  <div class="form-group">
+    <label>Pack to Migrate</label>
+    <select name="pack">
+      {{#each packs}}
+        <option value="{{this.metadata.id}}">{{this.title}} [{{this.metadata.packageName}}]</option>
+      {{/each}}
+    </select>
+  </div>
+  
+  <div class="form-group">
+    <button type="submit" data-action="migrate-world"><i class="fas fa-globe"></i> Migrate World</button>
+    <button type="submit" data-action="migrate-pack"><i class="fas fa-atlas"></i> Migrate Pack</button>
+  </div>
+</form>


### PR DESCRIPTION
Likely a final feature to finish the EOL transition for this module now that the system has its own enrichers. This migrates the world data and compendium packs to those enrichers.